### PR TITLE
Shipwire::Orders.new.find must return order information instead trackings

### DIFF
--- a/lib/shipwire/orders.rb
+++ b/lib/shipwire/orders.rb
@@ -9,7 +9,7 @@ module Shipwire
     end
 
     def find(id, params = {})
-      request(:get, "orders/#{id}/trackings", params: params)
+      request(:get, "orders/#{id}", params: params)
     end
 
     def update(id, body, params = {})


### PR DESCRIPTION
Shipwire::Orders.new.find must return order information instead trackings. Maybe was an error?