### PR TITLE
Update faraday version

### DIFF
--- a/lib/shipwire/version.rb
+++ b/lib/shipwire/version.rb
@@ -1,3 +1,3 @@
 module Shipwire
-  VERSION = "2.0.0"
+  VERSION = "2.0.1"
 end

--- a/shipwire.gemspec
+++ b/shipwire.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "deep_merge", "~> 1.0.0"
-  spec.add_dependency "faraday", "~> 0.9.1"
-  spec.add_dependency "faraday_middleware", "~> 0.10.0"
+  spec.add_dependency "faraday", "~> 0.12"
+  spec.add_dependency "faraday_middleware", "~> 0.12.2"
   spec.add_dependency "recursive-open-struct", "~> 0.6.4"
 
   spec.add_development_dependency "rspec",  "~> 3.2.0"


### PR DESCRIPTION
I'm not sure if this is useful for others or not but I ran into an issue where the Shipwire gem could not be used with Google API gems due to incompatible Faraday versions. This PR is the fork of Shipwire I am using to support Faraday 0.12.